### PR TITLE
Finally fixed the error.

### DIFF
--- a/ftp/main.py
+++ b/ftp/main.py
@@ -66,7 +66,8 @@ class FTPUploader():
 		tmpFilename = QDesktopServices.storageLocation(QDesktopServices.TempLocation) + "/" + ScreenCloud.formatFilename(str(timestamp))
 		screenshot.save(QFile(tmpFilename), ScreenCloud.getScreenshotFormat())
 
-		ftp = ftplib.FTP(self.host, int(self.port))
+		ftp = ftplib.FTP()
+		ftp.connect(self.host, self.port)
 		ftp.login(self.username, self.password)
 		f = open(tmpFilename, 'rb')
 		try:


### PR DESCRIPTION
This finally solves this problem
The ftplib.FTP class doesn't have a port argument, you have to use ftp.connect(host, port) instead.
I've tested this in my screencloud installation (Debian)