### PR TITLE
Fixed crash on imgur refresh access token

### DIFF
--- a/imgur/main.py
+++ b/imgur/main.py
@@ -82,7 +82,11 @@ class ImgurUploader():
 		self.loadSettings()
 		#Make sure we have a up to date token
 		if not self.uploadAnon:
-			self.imgur.refresh_access_token()
+			try:
+				self.imgur.refresh_access_token()
+			except Exception as e:
+				ScreenCloud.setError("Failed to refresh imgur access token. " + e.message)
+				return False
 		#Save to a temporary file
 		timestamp = time.time()
 		tmpFilename = QDesktopServices.storageLocation(QDesktopServices.TempLocation) + "/" + ScreenCloud.formatFilename(str(timestamp))


### PR DESCRIPTION
Fixes crash caused by imgur being down and unable to refresh access token

```
Failed to call ImgurUploader.isConfigured()
Traceback (most recent call last):
  File "<string>", line 85, in upload
  File "/home/gamingrobot/.local/share/data/screencloud/ScreenCloud/plugins/imgur/modules/pyimgur/__init__.py", line 1089, in refresh_access_token
    data_field=None)
  File "/home/gamingrobot/.local/share/data/screencloud/ScreenCloud/plugins/imgur/modules/pyimgur/__init__.py", line 712, in _send_request
    result = request.send_request(url, **kwargs)
  File "/home/gamingrobot/.local/share/data/screencloud/ScreenCloud/plugins/imgur/modules/pyimgur/request.py", line 91, in send_request
    content = resp.json()
  File "/home/gamingrobot/.local/share/data/screencloud/ScreenCloud/plugins/imgur/modules/requests/models.py", line 776, in json
    return json.loads(self.text, **kwargs)
  File "/usr/lib/python2.7/dist-packages/simplejson/__init__.py", line 488, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/dist-packages/simplejson/decoder.py", line 370, in decode
    obj, end = self.raw_decode(s)
  File "/usr/lib/python2.7/dist-packages/simplejson/decoder.py", line 389, in raw_decode
    return self.scan_once(s, idx=_w(s, idx).end())
simplejson.scanner.JSONDecodeError: Expecting value: line 2 column 1 (char 1)
```