### PR TITLE
Fixxes the byte presentation

### DIFF
--- a/shell/main.py
+++ b/shell/main.py
@@ -75,6 +75,7 @@ class ShellUploader():
 			elif self.outputIsUrl:
 				result = p.stdout.read()
 				result = result.strip()
+				result = bytes.decode(result)
 				ScreenCloud.setUrl(result)
 
 		except OSError:


### PR DESCRIPTION
Without this, every returned link looks like this: "b ' https://image.com/img.png';
So it gets returned as string and is ready to be copied in a instant messaging applicaiton for example